### PR TITLE
Propagate context to Consul calls in service2

### DIFF
--- a/service2/cmd/app/main.go
+++ b/service2/cmd/app/main.go
@@ -25,7 +25,7 @@ func main() {
 
 	logg := mw.NewLogger("service2")
 
-	appCfg, err := config.Load("consul:8500")
+	appCfg, err := config.Load(rootCtx, "consul:8500")
 	if err != nil {
 		werr := errors.WithStack(err)
 		logg.WithField("stack", fmt.Sprintf("%+v", werr)).WithError(err).

--- a/service2/internal/config/consul.go
+++ b/service2/internal/config/consul.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"context"
+
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/pkg/errors"
 )
@@ -11,7 +13,7 @@ type AppConfig struct {
 	HTTPPort   string
 }
 
-func Load(consulAddr string) (*AppConfig, error) {
+func Load(ctx context.Context, consulAddr string) (*AppConfig, error) {
 
 	cfg := &AppConfig{}
 
@@ -32,7 +34,8 @@ func Load(consulAddr string) (*AppConfig, error) {
 
 	// helper: get string value by key with fallback to current value
 	getKV := func(key, current string) string {
-		pair, _, err := kv.Get(key, nil)
+		opts := (&consulapi.QueryOptions{}).WithContext(ctx)
+		pair, _, err := kv.Get(key, opts)
 		if err != nil || pair == nil || len(pair.Value) == 0 {
 			return current
 		}


### PR DESCRIPTION
## Summary
- pass a context into Consul configuration loader and apply it to KV queries
- supply root context when loading config in the service2 app

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689dfcbf2f54832f9d1b6bcd59c49dd3