### PR TITLE
Expose service1 metrics on /metrics endpoint

### DIFF
--- a/service1/cmd/app/main.go
+++ b/service1/cmd/app/main.go
@@ -52,7 +52,9 @@ func main() {
 	hasherpb.RegisterHasherServiceServer(grpcServer, srv)
 
 	go func() {
-		if err := http.ListenAndServe(":2112", promhttp.Handler()); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.Handler())
+		if err := http.ListenAndServe(":2112", mux); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			werr := errors.WithStack(err)
 			log.WithField("stack", fmt.Sprintf("%+v", werr)).WithError(werr).Error("metrics server failed")
 		}


### PR DESCRIPTION
## Summary
- serve Service1 Prometheus metrics under /metrics so Prometheus scraping succeeds

## Testing
- `go test ./...` in service1
- `go test ./...` in service2


------
https://chatgpt.com/codex/tasks/task_e_689f3152f48c832fbfd05c35242f0313