### PR TITLE
feat: add redis caching to service2

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,8 @@ services:
         condition: service_started
       consul:
         condition: service_started
+      redis:
+        condition: service_started
   db:
     image: postgres:14.18
     environment:
@@ -115,6 +117,10 @@ services:
     volumes:
       - ./consul_data:/consul/data
       - ./consul_config:/consul/config
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
   prometheus:
     image: prom/prometheus:latest
     container_name: prometheus

--- a/service2/go.mod
+++ b/service2/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.2
+	github.com/redis/go-redis/v9 v9.12.1
 	github.com/sirupsen/logrus v1.9.3
 	google.golang.org/grpc v1.74.2
 	google.golang.org/protobuf v1.36.6
@@ -24,6 +25,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect

--- a/service2/go.sum
+++ b/service2/go.sum
@@ -14,6 +14,10 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3zCYjJFNM=
@@ -32,6 +36,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/fabienm/go-logrus-formatters v1.0.0 h1:kXRfZ/RWqicPOagDNQ+HttB3CWprencWx1cRfKxbgXM=
 github.com/fabienm/go-logrus-formatters v1.0.0/go.mod h1:QBlZ0LejpPDBjnKf+2u30xbAHSosPHP+dV/wxQlqsPw=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -226,6 +232,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/redis/go-redis/v9 v9.12.1 h1:k5iquqv27aBtnTm2tIkROUDp8JBXhXZIVu1InSgvovg=
+github.com/redis/go-redis/v9 v9.12.1/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/service2/internal/config/consul.go
+++ b/service2/internal/config/consul.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"time"
 
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/pkg/errors"
@@ -11,6 +12,8 @@ type AppConfig struct {
 	HasherPort string
 	DBDSN      string
 	HTTPPort   string
+	RedisAddr  string
+	CacheTTL   time.Duration
 }
 
 func Load(ctx context.Context, consulAddr string) (*AppConfig, error) {
@@ -45,6 +48,12 @@ func Load(ctx context.Context, consulAddr string) (*AppConfig, error) {
 	cfg.HTTPPort = getKV("config/service2/http_port", cfg.HTTPPort)
 	cfg.DBDSN = getKV("config/service2/db_dsn", cfg.DBDSN)
 	cfg.HasherPort = getKV("config/grpc_port", cfg.HasherPort)
+	cfg.RedisAddr = getKV("config/service2/redis_addr", cfg.RedisAddr)
+	if ttlStr := getKV("config/service2/redis_ttl", ""); ttlStr != "" {
+		if d, err := time.ParseDuration(ttlStr); err == nil {
+			cfg.CacheTTL = d
+		}
+	}
 
 	return cfg, nil
 }


### PR DESCRIPTION
## Summary
- configure Redis address and TTL via Consul config
- cache hashes in Redis when sending and checking
- wire Redis client in service2 application
- run Redis server in docker-compose and depend on it from service2

## Testing
- `go test ./...` in service1
- `go test ./...` in service2


------
https://chatgpt.com/codex/tasks/task_e_68a587f7b128832f801acf616e4e9a01